### PR TITLE
Publish to nuget as tool

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: ADOSCloneAllRepos CI-CD
 
 on:
   push:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -25,21 +25,21 @@ jobs:
     - name: Use GitVersion
       id: gitversion # step id used as reference for output values
       uses: gittools/actions/gitversion/execute@v0.9.2
-    # - name: Setup .NET Core
-    #   uses: actions/setup-dotnet@v1
-    #   with:
-    #     dotnet-version: 3.1.101
-    # - name: Install dependencies
-    #   run: dotnet restore
-    # - name: Build
-    #   run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.gitversion.outputs.semVer }}
-    # - name: Test
-    #   run: dotnet test --no-restore --verbosity normal
-    # - name: Upload ADOSCloneAllRepos
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: ADOSCloneAllRepos
-    #     path: ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.${{ steps.gitversion.outputs.semVer }}.nupkg
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.101
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.gitversion.outputs.semVer }}
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal
+    - name: Upload ADOSCloneAllRepos
+      uses: actions/upload-artifact@v2
+      with:
+        name: ADOSCloneAllRepos
+        path: ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.${{ steps.gitversion.outputs.semVer }}.nupkg
 
   publish_package:
     name: Publish to nuget.org
@@ -48,16 +48,16 @@ jobs:
 
     if: github.ref == 'refs/heads/publish-to-nuget-as-tool'
     steps:
-      # - name: Download build artifact
-      #   uses: actions/download-artifact@v1
-      #   with:
-      #     name: ADOSCloneAllRepos
-      # - name: Setup .NET Core
-      #   uses: actions/setup-dotnet@v1
-      #   with:
-      #     dotnet-version: 3.1.101
-      # - name: Push package to nuget.org
-      #   run: dotnet nuget push ./ADOSCloneAllRepos/ADOSCloneAllRepos.${{needs.build.outputs.semVer}}.nupkg -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
+      - name: Download build artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: ADOSCloneAllRepos
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+      - name: Push package to nuget.org
+        run: dotnet nuget push ./ADOSCloneAllRepos/ADOSCloneAllRepos.${{needs.build.outputs.semVer}}.nupkg -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
       - name: Tag commit
         uses: tvdias/github-tagger@v0.0.1
         with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: ADOSCloneAllRepos
-        path: ADOSCloneAllRepos\bin\Release\netcoreapp3.1
+        path: ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.*.nupkg
 
   publish_package:
     name: Publish to nuget.org

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -46,7 +46,7 @@ jobs:
     needs: build
     runs-on: windows-latest
 
-    if: github.ref == 'refs/heads/publish-to-nuget-as-tool'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v1

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: Upload ADOSCloneAllRepos
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: ADOSCloneAllRepos
         path: ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.${{ steps.gitversion.outputs.semVer }}.nupkg

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,9 +2,7 @@ name: ADOSCloneAllRepos CI-CD
 
 on:
   push:
-    branches:
-      - master
-      - publish-to-nuget-as-tool
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: ADOSCloneAllRepos
-        path: 'ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.*.nupkg'
+        path: ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.${{ steps.gitversion.outputs.semVer }}.nupkg
 
   publish_package:
     name: Publish to nuget.org

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -15,6 +15,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Fetch all history for all tags and branches
+      run: git fetch --prune --unshallow
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0.9.2
+      with:
+          versionSpec: '5.2.x'
+    - name: Use GitVersion
+      id: gitversion # step id used as reference for output values
+      uses: gittools/actions/gitversion/execute@v0.9.2
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
@@ -22,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore -p:Version=1.0.0.${{ github.run_id }}
+      run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.gitversion.outputs.semVer }}
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: Upload math result for job 2

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/upload-artifact@v1
       with:
         name: ADOSCloneAllRepos
-        path: ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.*.nupkg
+        path: 'ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.*.nupkg'
 
   publish_package:
     name: Publish to nuget.org

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -25,21 +25,21 @@ jobs:
     - name: Use GitVersion
       id: gitversion # step id used as reference for output values
       uses: gittools/actions/gitversion/execute@v0.9.2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.gitversion.outputs.semVer }}
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
-    - name: Upload ADOSCloneAllRepos
-      uses: actions/upload-artifact@v2
-      with:
-        name: ADOSCloneAllRepos
-        path: ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.${{ steps.gitversion.outputs.semVer }}.nupkg
+    # - name: Setup .NET Core
+    #   uses: actions/setup-dotnet@v1
+    #   with:
+    #     dotnet-version: 3.1.101
+    # - name: Install dependencies
+    #   run: dotnet restore
+    # - name: Build
+    #   run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.gitversion.outputs.semVer }}
+    # - name: Test
+    #   run: dotnet test --no-restore --verbosity normal
+    # - name: Upload ADOSCloneAllRepos
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: ADOSCloneAllRepos
+    #     path: ADOSCloneAllRepos\bin\Release\ADOSCloneAllRepos.${{ steps.gitversion.outputs.semVer }}.nupkg
 
   publish_package:
     name: Publish to nuget.org
@@ -48,16 +48,16 @@ jobs:
 
     if: github.ref == 'refs/heads/publish-to-nuget-as-tool'
     steps:
-      - name: Download build artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: ADOSCloneAllRepos
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 3.1.101
-      - name: Push package to nuget.org
-        run: dotnet nuget push ./ADOSCloneAllRepos/ADOSCloneAllRepos.${{needs.build.outputs.semVer}}.nupkg -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
+      # - name: Download build artifact
+      #   uses: actions/download-artifact@v1
+      #   with:
+      #     name: ADOSCloneAllRepos
+      # - name: Setup .NET Core
+      #   uses: actions/setup-dotnet@v1
+      #   with:
+      #     dotnet-version: 3.1.101
+      # - name: Push package to nuget.org
+      #   run: dotnet nuget push ./ADOSCloneAllRepos/ADOSCloneAllRepos.${{needs.build.outputs.semVer}}.nupkg -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
       - name: Tag commit
         uses: tvdias/github-tagger@v0.0.1
         with:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore -p:Version=1.0.${{ github.run_id }}
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: Upload math result for job 2

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,7 +2,9 @@ name: .NET Core
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - publish-to-nuget-as-tool
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     name: Build and test
     runs-on: windows-latest
+    # Map a step output to a job output
+    outputs:
+      semVer: ${{ steps.gitversion.outputs.semVer }}
 
     steps:
     - uses: actions/checkout@v2
@@ -47,10 +50,13 @@ jobs:
 
     if: github.ref == 'refs/heads/publish-to-nuget-as-tool'
     steps:
-      - name: Deploy app
-        run: |
-          echo "Deploying"
       - name: Download build artifact
         uses: actions/download-artifact@v1
         with:
           name: ADOSCloneAllRepos
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+      - name: Push package to nuget.org
+        run: dotnet nuget push ./ADOSCloneAllRepos/ADOSCloneAllRepos.${{needs.build.outputs.semVer}}.nupkg -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -58,3 +58,8 @@ jobs:
           dotnet-version: 3.1.101
       - name: Push package to nuget.org
         run: dotnet nuget push ./ADOSCloneAllRepos/ADOSCloneAllRepos.${{needs.build.outputs.semVer}}.nupkg -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
+      - name: Tag commit
+        uses: tvdias/github-tagger@v0.0.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{needs.build.outputs.semVer}}"

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore -p:Version=1.0.${{ github.run_id }}
+      run: dotnet build --configuration Release --no-restore -p:Version=1.0.0.${{ github.run_id }}
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: Upload math result for job 2

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   build:
     name: Build and test
-
     runs-on: windows-latest
 
     steps:
@@ -44,6 +43,8 @@ jobs:
   publish_package:
     name: Publish to nuget.org
     needs: build
+    runs-on: windows-latest
+
     if: github.ref == 'refs/heads/master'
     steps:
       - name: Deploy app

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -45,7 +45,7 @@ jobs:
     needs: build
     runs-on: windows-latest
 
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/publish-to-nuget-as-tool'
     steps:
       - name: Deploy app
         run: |

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    name: Build and test
 
     runs-on: windows-latest
 
@@ -34,8 +35,21 @@ jobs:
       run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.gitversion.outputs.semVer }}
     - name: Test
       run: dotnet test --no-restore --verbosity normal
-    - name: Upload math result for job 2
+    - name: Upload ADOSCloneAllRepos
       uses: actions/upload-artifact@v1
       with:
         name: ADOSCloneAllRepos
         path: ADOSCloneAllRepos\bin\Release\netcoreapp3.1
+
+  publish_package:
+    name: Publish to nuget.org
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Deploy app
+        run: |
+          echo "Deploying"
+      - name: Download build artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: ADOSCloneAllRepos

--- a/ADOSCloneAllRepos/ADOSCloneAllRepos.csproj
+++ b/ADOSCloneAllRepos/ADOSCloneAllRepos.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackAsTool>true</PackAsTool>
+    <ToolCommandName>adoscloneallrepos</ToolCommandName>
     <Description>Console app as a dotnet tool to clone all repositories from provided Azure DevOps organization.</Description>
     <PackageProjectUrl>https://github.com/realrubberduckdev/azure-devops-clone-all-repos</PackageProjectUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/ADOSCloneAllRepos/ADOSCloneAllRepos.csproj
+++ b/ADOSCloneAllRepos/ADOSCloneAllRepos.csproj
@@ -3,6 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackAsTool>true</PackAsTool>
+    <Description>Console app as a dotnet tool to clone all repositories from provided Azure DevOps organization.</Description>
+    <PackageProjectUrl>https://github.com/realrubberduckdev/azure-devops-clone-all-repos</PackageProjectUrl>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <Authors>https://github.com/realrubberduckdev/azure-devops-clone-all-repos/graphs/contributors</Authors>
+    <Company>https://github.com/realrubberduckdev/azure-devops-clone-all-repos</Company>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +18,10 @@
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.153.0" />
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.153.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="True" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/ADOSCloneAllRepos/Options.cs
+++ b/ADOSCloneAllRepos/Options.cs
@@ -8,7 +8,7 @@ namespace ADOSCloneAllRepos
         [Option('c', "collection-uri", Required = true, HelpText = "Azure collection e.g. https://dev.azure.com/sample-organization-name/")]
         public Uri CollectionUri { get; set; }
 
-        [Option('u', "user-name", Required = true, HelpText = "Git username e.g. username@microsoft.com")]
+        [Option('u', "user-name", Required = true, HelpText = "AzureDevOps username e.g. username@microsoft.com")]
         public string UserName { get; set; }
 
         [Option('p', "pat", Required = true, HelpText = "Personal Access Token (PAT) for the Git repositories")]

--- a/ADOSCloneAllRepos/Program.cs
+++ b/ADOSCloneAllRepos/Program.cs
@@ -11,7 +11,7 @@ namespace ADOSCloneAllRepos
 {
     class Program
     {
-        static void Main(string[] args) => 
+        static void Main(string[] args) =>
             Parser.Default.ParseArguments<Options>(args).WithParsed(options => CloneRepositories(options));
 
         static void CloneRepositories(Options options)

--- a/README.md
+++ b/README.md
@@ -44,8 +44,3 @@ Copyright (C) 2020 ADOSCloneAllRepos
 ## PAT
 PAT needs at least read all organization and projects and git clone permissions.
 Refer [Authenticate access with personal access tokens](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=preview-page) on how to generate a PAT.
-
-# Getting latest artifact
-Download artifact from latest Github action CI from master branch available at [.NET Core workflow](https://github.com/realrubberduckdev/azure-devops-clone-all-repos/actions?query=workflow%3A%22.NET+Core%22+branch%3Amaster+is%3Asuccess).
-
-![workflow-artifact](./imgs/workflow-artifact.png)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Copyright (C) 2020 ADOSCloneAllRepos
 
   -c, --collection-uri    Required. Azure collection e.g. https://dev.azure.com/sample-organization-name/
 
-  -u, --user-name         Required. Git username e.g. username@microsoft.com
+  -u, --user-name         Required. AzureDevOps username e.g. username@microsoft.com
 
   -p, --pat               Required. Personal Access Token (PAT) for the Git repositories
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
 ![ADOSCloneAllRepos CI](https://github.com/realrubberduckdev/azure-devops-clone-all-repos/workflows/.NET%20Core/badge.svg?branch=master)
 
 # ADOSCloneAllRepos
-Console app to clone all repositories from provided Azure DevOps organization.
+Dotnet tool to clone all repositories from provided Azure DevOps organization.
 
 # Usage
 
+## Installation
+Install tool from [nuget.org](https://www.nuget.org/packages/ADOSCloneAllRepos/).
+
+## Running
+If installed with `--global` or `-g` parameter, run using
+```
+ADOSCloneAllRepos.exe
+```
+
+If installed with `--local` parameter, run using
+```
+dotnet ADOSCloneAllRepos
+```
+
+## Command line reference
 Get help using the command:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![ADOSCloneAllRepos CI](https://github.com/realrubberduckdev/azure-devops-clone-all-repos/workflows/.NET%20Core/badge.svg?branch=master)
+![ADOSCloneAllRepos CI](https://github.com/realrubberduckdev/azure-devops-clone-all-repos/workflows/.NET%20Core/badge.svg?branch=master) [![Nuget (with prereleases)](https://img.shields.io/nuget/vpre/ADOSCloneAllRepos)](https://www.nuget.org/packages/ADOSCloneAllRepos/) [![Nuget](https://img.shields.io/nuget/dt/ADOSCloneAllRepos)](https://www.nuget.org/packages/ADOSCloneAllRepos/)
+
 
 # ADOSCloneAllRepos
 Dotnet tool to clone all repositories from provided Azure DevOps organization.


### PR DESCRIPTION
* Update documentation.
* Trigger publish_package job only on master branch.
* Create a git tag after publish.
* Trigger action on all branches.
* Pass semver to publish job and publish nupkg to nuget.org.
* Use gitversion for versioning. Refer https://github.com/marketplace/actions/use-actions for help.
* Pack console app as a dotnet tool.